### PR TITLE
Enable Renovate auto-merge for trusted reps

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,14 @@
+name: Auto-approve Renovate
+on:
+  schedule:
+    - cron: '1 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  id-token: write
+jobs:
+  approve:
+    uses: grafana/k6-ci/.github/workflows/auto-approve-renovate.yml@9477260e6838640d56c28aa95bcbf9a884ab21f3 # k6-ci#44 merge commit

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json",
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-automerge.json"
   ]
 }


### PR DESCRIPTION
## What?

Enables the k6 Renovate auto-merge approval flow, replicating the setup proven in [k6-pilot](https://github.com/grafana/k6-pilot).

- Extends `renovate.json` with [the shared preset](https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-automerge.json) for auto-merging trusted deps.
- Adds [a workflow](https://github.com/grafana/k6-ci/blob/main/.github/workflows/auto-approve-renovate.yml) that approves those PRs once all CI checks pass.

## Why?

To reduce the team's toll on Renovate PRs by 50%.

## Related PR(s)/Issue(s)

- grafana/k6-pilot#86
- grafana/k6-ci#44